### PR TITLE
adds `update_url` field

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -22,5 +22,9 @@
   ],
   "permissions": [
     "tabs"
-  ]
+  ],
+  // This is not really an update url. Is just that currently (Chrome Version 63.0.3239.108) a crx extension
+  // that is not present in the chrome store will need a update_url to work.
+  // Here were are adding the one from the repo because having this field with a valid url will make it work.
+  "update_url": "https://github.com/hexagonalconsulting/fav-ext"
 }


### PR DESCRIPTION
fix: add a `update_url` field in the manifest.json to make the .crx
generated with https://github.com/Zensight/extensionator work, even
when the extension is nor present in the chrome store.

just for reference (not need to read this):
Chorme currently have a bug that is the reason why we have to  add an update url if the extension is not present in the chorme store.
[more info here](https://bugs.chromium.org/p/chromium/issues/detail?id=794219)